### PR TITLE
Fixed I_IMAGENONE comparison in drawing tabs

### DIFF
--- a/src/mditab.c
+++ b/src/mditab.c
@@ -879,7 +879,7 @@ mditab_paint_item(mditab_t* mditab, HDC dc, UINT index, RECT* rect)
     mditab_calc_contents_rect(&contents, rect);
 
     /* Draw tab icon */
-    if(mditab->img_list != NULL  &&  item->img != (WORD) I_IMAGENONE) {
+    if(mditab->img_list != NULL  &&  item->img != (SHORT) I_IMAGENONE) {
         int ico_w, ico_h;
         RECT rect_ico;
 


### PR DESCRIPTION
Minor fix to mditabs for aligning text to the tab's left side when no image is present.  The typecasting was incorrect, which led to the text being shifted right in all cases.
