### PR TITLE
Added safety checks to string type conversions

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -154,13 +154,29 @@ mc_str_n_A2W(const char* from_str, int from_len, int* ptr_to_len)
     if(from_len < 0)
         from_len = (int)strlen((char*)from_str);
 
+    if(from_len == 0) {
+        if(ptr_to_len != NULL)
+            *ptr_to_len = 0;
+        return NULL;
+    }
+        
     to_len = MultiByteToWideChar(CP_ACP, 0, from_str, from_len, NULL, 0);
+    if(MC_ERR(to_len == 0)) {
+        MC_TRACE("mc_str_n_A2W: MultiByteToWideChar() check length failed.");
+        return NULL;
+    }
+    
     to_str = (WCHAR*) malloc((to_len + 1) * sizeof(WCHAR));
     if(MC_ERR(to_str == NULL)) {
         MC_TRACE("mc_str_n_A2W: malloc() failed.");
         return NULL;
     }
-    MultiByteToWideChar(CP_ACP, 0, from_str, from_len, to_str, to_len);
+    
+    if(MC_ERR(MultiByteToWideChar(CP_ACP, 0, from_str, from_len, to_str, to_len) == 0)) {
+        MC_TRACE("mc_str_n_A2W: MultiByteToWideChar() conversion failed.");
+        free(to_str);
+        return NULL;
+    }
     to_str[to_len] = L'\0';
 
     if(ptr_to_len != NULL)
@@ -181,15 +197,31 @@ mc_str_n_W2A(const WCHAR* from_str, int from_len, int* ptr_to_len)
     if(from_len < 0)
         from_len = (int)(wcslen((WCHAR*)from_str) * sizeof(WCHAR));
 
+    if(from_len == 0) {
+        if(ptr_to_len != NULL)
+            *ptr_to_len = 0;
+        return NULL;
+    }
+        
     to_len = WideCharToMultiByte(CP_ACP, 0, from_str, from_len,
                                  NULL, 0, NULL, NULL);
+    if(MC_ERR(to_len == 0)) {
+        MC_TRACE("mc_str_n_W2A: WideCharToMultiByte() check length failed.");
+        return NULL;
+    }
+    
     to_str = (char*) malloc(to_len + 1);
     if(MC_ERR(to_str == NULL)) {
         MC_TRACE("mc_str_n_W2A: malloc() failed.");
         return NULL;
     }
-    WideCharToMultiByte(CP_ACP, 0, from_str, from_len,
-                        to_str, to_len, NULL, NULL);
+    
+    if(MC_ERR(WideCharToMultiByte(CP_ACP, 0, from_str, from_len,
+                                  to_str, to_len, NULL, NULL) == 0)) {
+        MC_TRACE("mc_str_n_W2A: WideCharToMultiByte() conversion failed.");
+        free(to_str);
+        return NULL;
+    }
     to_str[to_len] = '\0';
 
     if(ptr_to_len != NULL)


### PR DESCRIPTION
I implemented these changes thinking there was an error occurring in these conversion routines.  Turns out I was incorrect.  However, I think the changes merit a commit.  Basically, the WideCharToMultiByte and it's reversed equivalent will return 0 when they fail.  The changes effectively:
1. Stop 0-length strings from being converted, returning NULL (and 0 length counts if applicable) with no error
2. Correctly handle occasions where the Windows conversions routines return 0 as an error

I doubt this breaks anything internally in mCtrl.
