### PR TITLE
Fixed intermittent crash in treelist when deleting a selected item.

### DIFF
--- a/src/treelist.c
+++ b/src/treelist.c
@@ -1332,6 +1332,9 @@ treelist_do_select(treelist_t* tl, treelist_item_t* item)
             treelist_invalidate_item(tl, old_sel, col_ix, 0);
     }
 
+    /* Set selected even if NULL */
+    tl->selected_item = item;
+
     if(item) {
         item->state |= MC_TLIS_SELECTED;
 
@@ -1344,8 +1347,6 @@ treelist_do_select(treelist_t* tl, treelist_item_t* item)
                     treelist_do_expand(tl, it, FALSE);
             }
         }
-
-        tl->selected_item = item;
 
         if(!tl->no_redraw)
             treelist_invalidate_item(tl, item, col_ix, 0);
@@ -2516,9 +2517,13 @@ treelist_delete_item(treelist_t* tl, treelist_item_t* item)
         tl->displayed_items -= displayed_del_count;
 
     /* If the selected item was deleted too, select another one. */
-    if(tl->selected_item != old_selected_item  &&  sel_replacement != NULL)
+    if(tl->selected_item != old_selected_item)
         treelist_do_select(tl, sel_replacement);
 
+    /* If the scrolled item is still our deleted one, reset */
+    if(tl->scrolled_item == item)
+        tl->scrolled_item = NULL;
+        
     /* Refresh */
     if(tl->displayed_items != old_displayed_items) {
         treelist_setup_scrollbars(tl);


### PR DESCRIPTION
On Win7 64-bit, I have been experiencing crashes deleting selected items from a Treelist control. It appears that the source of the crash was the possibility that the tl->scrolled_item could still be referencing the item that we've deleted, leading to some oddities during the subsequent updates after the deletion occurs. Additionally, I think that there may have been a dangling reference as the selected item as well because, if no selected item existed, it could cause our deleted item to hang around as the selected item. I could be very wrong on the selected item stuff, though.
