### PR TITLE
Refactored tooltip routines out of chart.c and into misc.c

### DIFF
--- a/src/chart.c
+++ b/src/chart.c
@@ -325,67 +325,26 @@ chart_DrawStringVert(gdix_Graphics* gfx, const WCHAR* str, INT str_len,
 static void
 tooltip_create(chart_t* chart)
 {
-    TTTOOLINFO info = { 0 };
-    NMTOOLTIPSCREATED ttc = { { 0 }, 0 };
-
-    chart->tooltip_win = CreateWindow(TOOLTIPS_CLASS, NULL, WS_POPUP,
-                                      0, 0, 0, 0, chart->win, 0, 0, 0);
-    if(MC_ERR(chart->tooltip_win == NULL)) {
-        MC_TRACE_ERR("tooltip_create: CreateWindow() failed");
-        return;
-    }
-
-    info.cbSize = sizeof(TTTOOLINFO);
-    info.uFlags = TTF_IDISHWND | TTF_TRACK | TTF_ABSOLUTE;
-    info.hwnd = chart->win;
-    MC_SEND(chart->tooltip_win, TTM_ADDTOOL, 0, &info);
-
-    ttc.hdr.hwndFrom = chart->win;
-    ttc.hdr.idFrom = GetWindowLong(chart->win, GWL_ID);
-    ttc.hdr.code = NM_TOOLTIPSCREATED;
-    ttc.hwndToolTips = chart->tooltip_win;
-    MC_SEND(chart->notify_win, WM_NOTIFY, ttc.hdr.idFrom, &ttc);
+    chart->tooltip_win = mc_tooltip_create(chart->win, chart->notify_win, TRUE);
 }
 
 static void
 tooltip_activate(chart_t* chart, BOOL show)
 {
-    TTTOOLINFO info = { 0 };
-
-    info.cbSize = sizeof(TTTOOLINFO);
-    info.hwnd = chart->win;
-    MC_SEND(chart->tooltip_win, TTM_TRACKACTIVATE, show, &info);
-
+    mc_tooltip_track_activate(chart->win, chart->tooltip_win, show);
     chart->tooltip_active = show;
 }
 
 static void
 tooltip_set_pos(chart_t* chart, int x, int y)
 {
-    TTTOOLINFO info = { 0 };
-    DWORD size;
-    POINT pt;
-
-    info.cbSize = sizeof(TTTOOLINFO);
-    info.hwnd = chart->win;
-
-    size = MC_SEND(chart->tooltip_win, TTM_GETBUBBLESIZE, 0, &info);
-    pt.x = x - LOWORD(size) / 2;
-    pt.y = y - HIWORD(size) - 5;
-    ClientToScreen(chart->win, &pt);
-    MC_SEND(chart->tooltip_win, TTM_TRACKPOSITION, 0, MAKELPARAM(pt.x, pt.y));
+    mc_tooltip_set_track_pos(chart->win, chart->tooltip_win, x, y);
 }
 
 static void
 tooltip_set_text(chart_t* chart, const TCHAR* str)
 {
-    TTTOOLINFO info = { 0 };
-
-    info.cbSize = sizeof(TTTOOLINFO);
-    info.uFlags = TTF_IDISHWND | TTF_TRACK | TTF_ABSOLUTE;
-    info.hwnd = chart->win;
-    info.lpszText = (TCHAR*) str;
-    MC_SEND(chart->tooltip_win, TTM_UPDATETIPTEXT, 0, &info);
+    mc_tooltip_set_text(chart->win, chart->tooltip_win, str);
 }
 
 static void

--- a/src/misc.c
+++ b/src/misc.c
@@ -613,6 +613,80 @@ mc_fini_module(void)
     ImageList_Destroy(mc_bmp_glyphs);
 }
 
+/****************
+ *** Tooltips ***
+ ****************/
+
+HWND
+mc_tooltip_create(HWND parent, HWND notify, BOOL track)
+{
+    HWND ret;
+    TTTOOLINFO info = { 0 };
+    NMTOOLTIPSCREATED ttc = { { 0 }, 0 };
+
+    ret = CreateWindow(TOOLTIPS_CLASS, NULL, WS_POPUP,
+                       0, 0, 0, 0, parent, 0, 0, 0);
+    if(MC_ERR(ret == NULL)) {
+        MC_TRACE_ERR("tooltip_create: CreateWindow() failed");
+        return NULL;
+    }
+
+    info.cbSize = sizeof(TTTOOLINFO);
+    info.uFlags = TTF_IDISHWND | TTF_ABSOLUTE;
+    if(track)
+        info.uFlags |= TTF_TRACK;
+        
+    info.hwnd = parent;
+    MC_SEND(ret, TTM_ADDTOOL, 0, &info);
+
+    if(notify != NULL) {
+        ttc.hdr.hwndFrom = parent;
+        ttc.hdr.idFrom = GetWindowLong(parent, GWL_ID);
+        ttc.hdr.code = NM_TOOLTIPSCREATED;
+        ttc.hwndToolTips = ret;
+        MC_SEND(notify, WM_NOTIFY, ttc.hdr.idFrom, &ttc);
+    }
+    
+    return ret;
+}
+
+void
+mc_tooltip_track_activate(HWND parent, HWND tooltip, BOOL show)
+{
+    TTTOOLINFO info = { 0 };
+
+    info.cbSize = sizeof(TTTOOLINFO);
+    info.hwnd = parent;
+    MC_SEND(tooltip, TTM_TRACKACTIVATE, show, &info);
+}
+
+void
+mc_tooltip_set_track_pos(HWND parent, HWND tooltip, int x, int y)
+{
+    TTTOOLINFO info = { 0 };
+    DWORD size;
+    POINT pt;
+
+    info.cbSize = sizeof(TTTOOLINFO);
+    info.hwnd = parent;
+
+    size = MC_SEND(tooltip, TTM_GETBUBBLESIZE, 0, &info);
+    pt.x = x - LOWORD(size) / 2;
+    pt.y = y - HIWORD(size) - 5;
+    ClientToScreen(parent, &pt);
+    MC_SEND(tooltip, TTM_TRACKPOSITION, 0, MAKELPARAM(pt.x, pt.y));
+}
+
+void
+mc_tooltip_set_text(HWND parent, HWND tooltip, const TCHAR* str)
+{
+    TTTOOLINFO info = { 0 };
+
+    info.cbSize = sizeof(TTTOOLINFO);
+    info.hwnd = parent;
+    info.lpszText = (TCHAR*) str;
+    MC_SEND(tooltip, TTM_UPDATETIPTEXT, 0, &info);
+}
 
 /*****************
  *** DllMain() ***

--- a/src/misc.h
+++ b/src/misc.h
@@ -536,5 +536,20 @@ mc_track_mouse(HWND win, DWORD flags)
     TrackMouseEvent(&tme);
 }
 
+/****************
+ *** Tooltips ***
+ ****************/
+ 
+/* Creates a tooltip window that is optionally a tracked tooltip */
+HWND mc_tooltip_create(HWND parent, HWND notify, BOOL track);
+
+/* Activates a tracking tooltip */
+void mc_tooltip_track_activate(HWND parent, HWND tooltip, BOOL show);
+
+/* Sets the position of our tracking tooltip */
+void mc_tooltip_set_track_pos(HWND parent, HWND tooltip, int x, int y);
+
+/* Update the text of a tooltip */
+void mc_tooltip_set_text(HWND parent, HWND tooltip, const TCHAR* str);
 
 #endif  /* MC_MISC_H  */


### PR DESCRIPTION
This simple refactor pulls some of the tooltip-specific code out of chart.c such that other controls that might use portions of the tooltip code can do so without replication.  The refactor has been tested with the chart example, and it seems to work fine.

This pull request does not add any features.
