### PR TITLE
HTML control: Added ability to intercept and selectively allow navigation attempts

### DIFF
--- a/include/mCtrl/html.h
+++ b/include/mCtrl/html.h
@@ -621,6 +621,19 @@ typedef struct MC_NMHTTPERRORA_tag {
  */
 #define MC_HN_HTTPERROR          (MC_HN_FIRST + 7)
 
+ /**
+ * @brief Fired before the browser navigates to a new URL. 
+ *
+ * Note that this is sent before (@ref MC_HN_APPLINK), and returning non-zero 
+ * will prevent (@ref MC_HN_APPLINK) from being sent.
+ *  
+ * @param[in] wParam (@c int) Id of the control sending the notification.
+ * @param[in] lParam (@ref MC_NMHTMLURL*) Pointer to a structure specifying
+ * details about the URL. 
+ * @return Application should return zero if navigation should continue.
+ */
+#define MC_HN_BEFORENAVIGATE     (MC_HN_FIRST + 8)
+
 /*@}*/
 
 

--- a/src/html.c
+++ b/src/html.c
@@ -225,7 +225,10 @@ dispatch_Invoke(IDispatch* self, DISPID disp_id, REFIID riid, LCID lcid,
 
             HTML_TRACE("dispatch_Invoke: DISPID_BEFORENAVIGATE2(%S)", url);
 
-            if(url != NULL  &&  wcsncmp(url, L"app:", 4) == 0) {
+            if (html_notify_text(html, MC_HN_BEFORENAVIGATE, url) != 0) {
+                *cancel = VARIANT_TRUE;
+            }
+            else if(url != NULL  &&  wcsncmp(url, L"app:", 4) == 0) {
                 html_notify_text(html, MC_HN_APPLINK, url);
                 *cancel = VARIANT_TRUE;
             }


### PR DESCRIPTION
A slight alternation to our [previous discussion](https://github.com/Psiphon-Inc/mctrl/commit/b0dfece364e4aeedf91de182e252cbdb7bbd3e5c#commitcomment-10153586): I used `MC_HN_BEFORENAVIGATE` rather than `MC_HN_BEFORENAVIGATION` to better match the internal message.

@mity: Note that I amended my previous `NAVLINK` commit, so if you had pulled that from my fork you'll have some merging to do.