### PR TITLE
Menubar: Don't treat AltGr as Alt

### DIFF
--- a/mctrl/menubar.c
+++ b/mctrl/menubar.c
@@ -917,7 +917,8 @@ mcIsMenubarMessage(HWND hwndMenubar, LPMSG lpMsg)
             /* Handle <F10> or <ALT> */
             if(active_menubar != NULL)
                 break;
-            if((lpMsg->wParam == VK_MENU || (lpMsg->wParam == VK_F10 && !(lpMsg->lParam & 0x20000000)))  &&
+            if(((lpMsg->wParam == VK_MENU && lpMsg->message == WM_SYSKEYDOWN) ||
+                (lpMsg->wParam == VK_F10 && !(lpMsg->lParam & 0x20000000)))  &&
                !(GetKeyState(VK_SHIFT) & 0x8000))
             {
                 if(lpMsg->wParam == VK_MENU)
@@ -933,7 +934,8 @@ mcIsMenubarMessage(HWND hwndMenubar, LPMSG lpMsg)
             /* Handle <F10> or <ALT> */
             if(active_menubar != NULL)
                 break;
-            if((lpMsg->wParam == VK_MENU || (lpMsg->wParam == VK_F10 && !(lpMsg->lParam & 0x20000000)))  &&
+            if(((lpMsg->wParam == VK_MENU && lpMsg->message == WM_SYSKEYUP) ||
+                (lpMsg->wParam == VK_F10 && !(lpMsg->lParam & 0x20000000)))  &&
                !(GetKeyState(VK_SHIFT) & 0x8000))
             {
                 if(mb == activate_with_f10) {


### PR DESCRIPTION
On keyboards that differentiate between the <kbd>Alt</kbd> and <kbd>AltGr</kbd> keys and use the latter for entering characters (e.g. German or Czech keyboards), <kbd>AltGr</kbd> shouldn’t be used a menu shortcut — but mCtrl doesn’t distinguish between them.

Steps to reproduce: in an application using mCtrl menubar, try to type € using Czech keyboard by pressing <kbd>AltGr</kbd>+<kbd>E</kbd> (or left <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>E</kbd>, which is the same thing due to how <kbd>AltGr</kbd> is represented in win32). Observe how the menu gets highlighted as you release <kbd>AltGr</kbd>. Compare with Notepad where this doesn’t happen.

Fortunately it’s easy to distinguish them: `VK_MENU` corresponds to <kbd>Alt</kbd> only in `WM_SYSKEY{DOWN,UP}` messages, but not in `WM_KEY{DOWN,UP}` ([source](https://blogs.msdn.microsoft.com/murrays/2015/04/20/hot-keys-and-altgr/)) and so this can be fixed easily. This PR does just that (both Alts continue to work on US keyboard).
