### PR TITLE
Rework/cleanup of `<ALT>` handling in `mcIsMenubarMessage()`

### DIFF
--- a/mctrl/menubar.c
+++ b/mctrl/menubar.c
@@ -967,7 +967,6 @@ mcIsMenubarMessage(HWND hwndMenubar, LPMSG lpMsg)
             return TRUE;
 
         case WM_SYSCHAR:
-        case WM_CHAR:
             /* Handle hot keys (<ALT> + something) */
             if(lpMsg->wParam != VK_MENU  &&  (lpMsg->lParam & 0x20000000)) {
                 UINT item;

--- a/mctrl/menubar.c
+++ b/mctrl/menubar.c
@@ -980,7 +980,6 @@ mcIsMenubarMessage(HWND hwndMenubar, LPMSG lpMsg)
                     /* Disable the delayed activation if it is an hotkey not
                      * present in the menubar. */
                     delayed_activation = FALSE;
-                    MessageBeep(0xffffffff);
                 }
             }
             break;

--- a/mctrl/menubar.c
+++ b/mctrl/menubar.c
@@ -762,7 +762,7 @@ menubar_ht_proc(int code, WPARAM wp, LPARAM lp)
                     case VK_MENU:
                     case VK_F10:
                         menubar_ht_change_dropdown(mb, -1, TRUE);
-                        return 0;
+                        return 1;   /* Consume the message. */
 
                     case VK_LEFT:
                         if(menubar_ht_sel_menu == NULL  ||
@@ -774,6 +774,7 @@ menubar_ht_proc(int code, WPARAM wp, LPARAM lp)
                             MENUBAR_TRACE("menubar_ht_proc: Change dropdown by VK_LEFT");
                             if(item != mb->pressed_item)
                                 menubar_ht_change_dropdown(mb, item, TRUE);
+                            return 1;   /* Consume the message. */
                         }
                         break;
 
@@ -788,6 +789,7 @@ menubar_ht_proc(int code, WPARAM wp, LPARAM lp)
                             MENUBAR_TRACE("menubar_ht_proc: Change dropdown by VK_RIGHT");
                             if(item != mb->pressed_item)
                                 menubar_ht_change_dropdown(mb, item, TRUE);
+                            return 1;   /* Consume the message. */
                         }
                         break;
                 }


### PR DESCRIPTION
This is a counter-proposal to patch #51.