### PR TITLE
Static build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,13 @@ include_directories("${PROJECT_SOURCE_DIR}/lib/md4c-utf16")
 set(HSLUV_C_TESTS OFF CACHE BOOL "Disable building hsluv-c tests.")
 set(MCTRL_BUILD_COMPLETETREE ON CACHE BOOL "Tell examples/CMakeListst.txt it is built as part of complete mCtrl build.")
 
+
 OPTION(MCTRL_BUILD_EXAMPLES "Enable/disable building of mCtrl examples" ON)
 OPTION(MCTRL_BUILD_TESTS "Enable/disable building of mCtrl tests" ON)
+
+# Note this an experimental feature.
+# See discussion in https://github.com/mity/mctrl/issues/75
+OPTION(MCTRL_BUILD_STATIC "Enable/disable build of mCtrl as a static lib" OFF)
 
 
 if(MSVC)

--- a/doxygen/design.dox
+++ b/doxygen/design.dox
@@ -163,23 +163,11 @@
  * loaded in runtime. In such cases, mCtrl tries to behave in a reasonable
  * manner even if those libraries or are not available:
  *
- * - @c UXTHEME.DLL is used on Windows XP and newer to paint the mCtrl controls
- *   using a current visual theme. Note mCtrl does so only if the application
- *   uses @c COMMCTRL32.DLL version 6 or newer, to be visually consistent with
- *   the standard controls within the application.
+ * - @c D2D1.DLL (Direct2d) and @c DWRITE.DLL (DirectWrite) are used by some
+ *   controls for high quality painting, e.g. when anti-aliasing support or
+ *   alpha channel is needed.
  *
- * - @c D2D1.DLL (Direct2d) and @c DWRITE.DLL (DirectWrite) are used for high
- *   quality painting, e.g. when anti-aliasing support or alpha channel is
- *   needed. Direct2D and DirectWrite are only available since MS Vista
- *   (with some Service Pack or other updates) and newer Windows versions.
- *
- * - @c GDIPLUS.DLL (GDI+) is used as a fall back if Direct2d+DirectWrite are
- *   not available on the system. GDI+ is available since Windows 2000 with
- *   some Service Packs or updates installed.
- *
- * @attention To make @c MCTRL.DLL working on all Windows 2000, even when the
- * system lacks the library, you may need to deploy the redistributable version
- * of GDI+ v. 1.0 into your application directory, when installing your
- * application. The redistributable @c GDIPLUS.DLL can be obtained from
- * Microsoft.
+ * - @c DWMAPI.DLL (Desktop Window Manager) is used by the MDI tab control
+ *   in order to place the control into a possibly extended non-client area
+ *   of top-level window.
  */

--- a/doxygen/intro.dox
+++ b/doxygen/intro.dox
@@ -58,12 +58,17 @@
  * #include <mCtrl.h>
  * @endcode
  *
- * Finally, link with the appropriate import library. Import libraries live
- * in subdirectory @c lib or @c lib64 (for 32-bit or 64-bit binaries
- * respectively). In both directories, thw following import libs can be found:
+ * Finally, link with the appropriate library. Most application should use
+ * the dynamic @c MCTRL.DLL. Import libraries live in subdirectory @c lib or
+ * @c lib64 (for 32-bit or 64-bit binaries respectively). In both directories,
+ * the following import libs can be found:
  * - @c libmctrl.a intended for gcc-based toolchains (e.g. mingw).
  * - @c mCtrl.lib intended for MS Visual Studio and Microsoft C compiler.
  *
  * Of course you have then distribute your applications with @c MCTRL.DLL,
  * which is located in subdirectory @c bin or @c bin64 respectively.
+ *
+ * Alternatively, application may link with a static library. However this
+ * involves obstacles and should generally be used only when there is a strong
+ * reason. See @ref mCtrl/staticlib.h for more information about this.
  */

--- a/doxygen/main.dox
+++ b/doxygen/main.dox
@@ -33,7 +33,6 @@
  * @subsection toc_general General Design
  * - @ref page_intro
  * - @ref page_design
- * - @ref page_static
  * - @ref page_debug
  *
  * @subsection toc_controls Control Reference
@@ -55,6 +54,7 @@
  * - @ref mctrl.h - All-in-one header
  * - @ref mCtrl/dialog.h - Dialog functions
  * - @ref mCtrl/version.h - Retrieving mCtrl version
+ * - @ref mCtrl/staticlib.h - Helper when using mCtrl built as a static library
  *
  * @subsection toc_misc Miscellaneous Headers
  * (Do not include these directly.)

--- a/doxygen/main.dox
+++ b/doxygen/main.dox
@@ -33,6 +33,7 @@
  * @subsection toc_general General Design
  * - @ref page_intro
  * - @ref page_design
+ * - @ref page_static
  * - @ref page_debug
  *
  * @subsection toc_controls Control Reference

--- a/doxygen/static.dox
+++ b/doxygen/static.dox
@@ -1,0 +1,5 @@
+/**
+ * @page page_static Static Library
+ *
+ * TBD
+ */

--- a/doxygen/static.dox
+++ b/doxygen/static.dox
@@ -1,5 +1,0 @@
-/**
- * @page page_static Static Library
- *
- * TBD
- */

--- a/include/mCtrl/staticlib.h
+++ b/include/mCtrl/staticlib.h
@@ -35,10 +35,19 @@ extern "C" {
  * @file
  * @brief Helper header when using mCtrl as a static library.
  *
+ * @attention This is a new and experimental feature. It may be subject to any
+ * change, even a removal, if it turns out as too problematic.
+ *
+ * @note Currently, building of the static library is by default disabled and
+ * the pre-built binary packages do not contain the static libraries. If you
+ * want to use the static lib, you have to build mCtrl from sources and enable
+ * the feature by specifying @c -DCMAKE_BUILD_STATIC on cmake command line.
+ *
  * @note This header is not included by the all-in-one @c mCtrl.h. Include it
  * manually if and only if you link with mCtrl as a static library.
  * This helper provides prototypes of global initialization and termination
  * (which is otherwise implemented by @c DllMain() when linking with DLL.)
+ *
  *
  * @section sec_static_init Static Library Initialization
  *

--- a/include/mCtrl/staticlib.h
+++ b/include/mCtrl/staticlib.h
@@ -1,0 +1,115 @@
+/*
+ * mCtrl: Additional Win32 controls
+ * <https://github.com/mity/mctrl>
+ * <https://mctrl.org>
+ *
+ * Copyright (c) 2020 Martin Mitas
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MCTRL_STATICLIB_H
+#define MCTRL_STATICLIB_H
+
+#include <mCtrl/_defs.h>
+#include <mCtrl/_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @file
+ * @brief Helper header when using mCtrl as a static library.
+ *
+ * @note This header is not included by the all-in-one @c mCtrl.h. Include it
+ * manually if and only if you link with mCtrl as a static library.
+ * This helper provides prototypes of global initialization and termination
+ * (which is otherwise implemented by @c DllMain() when linking with DLL.)
+ *
+ * @section sec_static_init Static Library Initialization
+ *
+ * When linking with the static library, application has to call explicitly
+ * function @ref mcInitialize() before any other per-module initialization
+ * is performed, and @ref mcTerminate() after mCtrl is not used anymore.
+ *
+ * These functions perform some initialization or clean-up which normally takes
+ * place when @c DllMain() of @c MCTRL.DLL is called.
+ *
+ * Unlike other per-module initialization functions, there is no reference
+ * counting and both the functions should be called exactly once.
+ *
+ * Application may call these functions from the context of its @c DllMain()
+ * (when linking the static mCtrl lib into a DLL target).
+ *
+ *
+ * @section sec_static_resources Static Library and Resources.
+ *
+ * Some mCtrl controls require some resources like e.g. cursors or bitmaps
+ * used when painting the control.
+ *
+ * Normally, these resources are embedded in @c MCTRL.DLL, and mCtrl code
+ * loads them normally via @c LoadResource() or other appropriate Win32 API
+ * function.
+ *
+ * However, this is not possible when using mCtrl as a static library. If the
+ * application uses any mCtrl control or functionality which requires loading
+ * any such resource, the application developer must make sure the required
+ * resource is available in the @c .EXE or @c .DLL module which links with the
+ * mCtrl static library.
+ *
+ * The static library allows to specify a custom resource ID base so that
+ * application developer can place all the resources into a range of his choice
+ * where it does not collide with with resource IDs of the application itself.
+ * This ID base has then be passed as the 2nd argument of @ref mcInitialize().
+ *
+ * In other words, if @c MCTRL.DLL uses some particular resource with ID 100
+ * then, in the case of the static lib, mCtrl code will attempt to load the
+ * resource with ID equal to <tt>(100 + iResourceIdBase)</tt> where @c
+ * iResourceIdBase is the custom resource ID base.
+ *
+ * Note application does not need to provide all resources available in @c
+ * MCTRL.DLL, only a subset required by the functionality the application uses.
+ *
+ * @attention Please remember we cannot provide any compatibility guarantees
+ * for the resources. New resources may be added or some resources can be
+ * modified or removed in the future versions of mCtrl. When using mCtrl as a
+ * static lib, application developer has to check whether such a change has
+ * happened whenever migrating to a new mCtrl version.
+ */
+
+
+/**
+ * Perform global initialization (when mCtrl is linked in as a static library).
+ *
+ * @param hInstance Handle of the .EXE or .DLL module the static library is
+ * linked into.
+ * @param iResourceIdBase See @ref sec_static_resources
+ * @return @c TRUE if the initialization is successful, @c FALSE otherwise.
+ */
+BOOL MCTRL_API mcInitialize(HINSTANCE hInstance, int iResourceIdBase);
+
+/**
+ * Perform global clean-up (when mCtrl is linked in as a static library).
+ */
+void MCTRL_API mcTerminate(void);
+
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif  /* MCTRL_STATICLIB_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 set(CRE_PATH "${PROJECT_SOURCE_DIR}/lib/c-reusables")
 
-add_library(mCtrl SHARED
-    mCtrl.def
-
+set(SOURCES
     # from c-reusables
     ${CRE_PATH}/data/buffer.c       ${CRE_PATH}/data/buffer.h
     ${CRE_PATH}/win32/memstream.c   ${CRE_PATH}/win32/memstream.h
@@ -41,7 +39,7 @@ add_library(mCtrl SHARED
     module.c                        module.h
     mousedrag.c                     mousedrag.h
     mousewheel.c                    mousewheel.h
-    resource.h                      resource.rc
+    resource.h
     rgn16.c                         rgn16.h
     table.c                         table.h         ../include/mCtrl/table.h
     tooltip.c                       tooltip.h
@@ -56,9 +54,15 @@ add_library(mCtrl SHARED
     xwic.c                          xwic.h
 )
 
+add_library(mCtrl SHARED ${SOURCES} mCtrl.def resource.rc)
 target_link_libraries(mCtrl
     gdi32 comctl32 ole32 oleaut32 shell32 uuid uxtheme windowscodecs    # Windows SDK libs
     hsluv-c md4c-utf16)                                                 # Libs distributed with us
+
+if(MCTRL_BUILD_STATIC)
+    add_library(mCtrl_static STATIC ${SOURCES})
+    target_compile_definitions(mCtrl_static  PRIVATE -DMCTRL_BUILD_STATIC)
+endif()
 
 add_definitions(-DMCTRL_BUILD)
 add_definitions(-DUNICODE -D_UNICODE)

--- a/src/expand.c
+++ b/src/expand.c
@@ -954,7 +954,7 @@ expand_init_module(void)
 
     for(i = 0; i < MC_SIZEOF_ARRAY(expand_glyphs); i++) {
         expand_glyphs[i].bmp = LoadImage(mc_instance,
-                    MAKEINTRESOURCE(expand_glyphs[i].res_id), IMAGE_BITMAP,
+                    MC_RES_ID(expand_glyphs[i].res_id), IMAGE_BITMAP,
                     0, 0, LR_SHARED | LR_CREATEDIBSECTION);
     }
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -3828,8 +3828,7 @@ grid_init_module(void)
     WNDCLASS wc = { 0 };
 
     for(i = 0; i < MC_SIZEOF_ARRAY(grid_cursor); i++) {
-        grid_cursor[i].cur = LoadCursor(mc_instance,
-                                        MAKEINTRESOURCE(grid_cursor[i].res_id));
+        grid_cursor[i].cur = LoadCursor(mc_instance, MC_RES_ID(grid_cursor[i].res_id));
         if(MC_ERR(grid_cursor[i].cur == NULL)) {
             MC_TRACE("grid_init_module: LoadCursor(%d) failed [%lu]",
                      grid_cursor[i].res_id, GetLastError());

--- a/src/imgview.c
+++ b/src/imgview.c
@@ -296,7 +296,7 @@ imgview_nccreate(HWND win, CREATESTRUCT* cs)
     if(cs->lpszName != NULL) {
 #ifdef UNICODE
         if(cs->lpszName != NULL  &&  cs->lpszName[0] == 0xffff)
-            cs->lpszName = MAKEINTRESOURCE(cs->lpszName[1]);
+            cs->lpszName = MC_RES_ID(cs->lpszName[1]);
 #endif
         imgview_load_resource(iv, cs->hInstance, cs->lpszName, MC_IS_UNICODE);
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -253,6 +253,26 @@ mc_mutex_unlock(mc_mutex_t* mutex)
 #endif
 
 
+/**************************
+ *** Resource Utilities ***
+ **************************/
+
+/* In case of static build, we have to allow application to remap the resource
+ * IDs to an arbitrary range so that our resource IDs do not collide with
+ * app's own resources.
+ *
+ * In order to support that, we have to use MC_RES_ID() instead of
+ * MAKEINTRESOURCE().
+ */
+#ifdef MCTRL_BUILD_STATIC
+    extern int mc_resource_id_base;
+
+    #define MC_RES_ID(raw_id)   MAKEINTRESOURCE(mc_resource_id_base + (raw_id))
+#else
+    #define MC_RES_ID(raw_id)   MAKEINTRESOURCE(raw_id)
+#endif
+
+
 /************************
  *** String Utilities ***
  ************************/


### PR DESCRIPTION
(Fixes #75)

Current status:
 * It should be more or less complete.
 * It is not tested at all.
 * It has to be explicitly enabled via CMake option (`-DCMAKE_BUILD_STATIC`). With that option both the DLL and the static lib are built.

To do: 
 * ~~Documentation (the file doxygen/static.dox)~~ (Done.)
 * ~~Consider enabling it when doing the binary release packages and distribute the static libs in the pre-built packages.~~ (Not now. Maybe later when we remove the experimental status of the feature.)

@namazso: It would be cool if you could review it and test it.
