### PR TITLE
Fix ARM64 misdetected as not being 64 bit

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -669,17 +669,17 @@ setup_win_version(void)
                 fn_IsWow64Process(GetCurrentProcess(), &is_64bit);
         }
         if (!is_64bit) {
-          BOOL(WINAPI * fn_IsWow64Process2)(HANDLE, USHORT*, USHORT*);
-          USHORT process_machine;
-          USHORT native_machine;
-
-          fn_IsWow64Process2 = (BOOL(WINAPI*)(HANDLE, USHORT*, USHORT*))
-            GetProcAddress(mc_instance_kernel32, "IsWow64Process2");
-          if (fn_IsWow64Process2 != NULL) {
-            fn_IsWow64Process2(GetCurrentProcess(), &process_machine, &native_machine);
-            if (native_machine == IMAGE_FILE_MACHINE_ARM64)
-              is_64bit = TRUE;
-          }
+            BOOL(WINAPI * fn_IsWow64Process2)(HANDLE, USHORT*, USHORT*);
+            
+            fn_IsWow64Process2 = (BOOL(WINAPI*)(HANDLE, USHORT*, USHORT*))
+                        GetProcAddress(mc_instance_kernel32, "IsWow64Process2");
+            if (fn_IsWow64Process2 != NULL) {
+                USHORT process_machine;
+                USHORT native_machine;
+                fn_IsWow64Process2(GetCurrentProcess(), &process_machine, &native_machine);
+                if (native_machine == IMAGE_FILE_MACHINE_ARM64)
+                    is_64bit = TRUE;
+            }
         }
         if(is_64bit)
             prefix = "64-bit ";

--- a/src/misc.c
+++ b/src/misc.c
@@ -664,6 +664,19 @@ setup_win_version(void)
             if(fn_IsWow64Process != NULL)
                 fn_IsWow64Process(GetCurrentProcess(), &is_64bit);
         }
+        if (!is_64bit) {
+          BOOL(WINAPI * fn_IsWow64Process2)(HANDLE, USHORT*, USHORT*);
+          USHORT process_machine;
+          USHORT native_machine;
+
+          fn_IsWow64Process2 = (BOOL(WINAPI*)(HANDLE, USHORT*, USHORT*))
+            GetProcAddress(mc_instance_kernel32, "IsWow64Process2");
+          if (fn_IsWow64Process2 != NULL) {
+            fn_IsWow64Process2(GetCurrentProcess(), &process_machine, &native_machine);
+            if (native_machine == IMAGE_FILE_MACHINE_ARM64)
+              is_64bit = TRUE;
+          }
+        }
         if(is_64bit)
             prefix = "64-bit ";
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -649,6 +649,10 @@ setup_win_version(void)
 #ifdef DEBUG
     /* Log the detected Windows version. */
     {
+#ifndef IMAGE_FILE_MACHINE_ARM64
+    #define IMAGE_FILE_MACHINE_ARM64    0xAA64
+#endif
+        
         const char* name = "???";
         const char* prefix = "";
         const char* suffix = "";


### PR DESCRIPTION
~~IsWow64Process2 is only on Win10, so I'm not sure how one would solve this issue for IA-64, although that isn't supported by Windows since 8 anyways.~~ Apparently IsWow64Process is true for IA-64.

Edit: Also, would it be possible to have ARM64 prebuilt binaries in the next release?